### PR TITLE
Fix MainController endpoint paths

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/javafx/MainController.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/javafx/MainController.java
@@ -113,7 +113,7 @@ public class MainController {
 
             // 4) Crear la petición HTTP POST
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("http://localhost:8080/solicitudes/adjuntar"))
+                    .uri(URI.create("http://localhost:8080/api/solicitudes/adjuntar"))
                     .header("Content-Type", "multipart/form-data; boundary=" + boundary)
                     .POST(bodyPublisher)
                     .build();
@@ -140,7 +140,7 @@ public class MainController {
     private void handleRefrescar() {
         try {
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("http://localhost:8080/solicitudes"))
+                    .uri(URI.create("http://localhost:8080/api/solicitudes"))
                     .GET()
                     .build();
 
@@ -211,7 +211,7 @@ public class MainController {
     private void cambiarEstado(Long id, String nuevoEstado) {
         try {
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("http://localhost:8080/solicitudes/" + id + "/estado?estado=" + nuevoEstado))
+                    .uri(URI.create("http://localhost:8080/api/solicitudes/" + id + "/estado?estado=" + nuevoEstado))
                     .PUT(HttpRequest.BodyPublishers.noBody())
                     .build();
 


### PR DESCRIPTION
## Summary
- update HTTP URLs in `MainController` to use `/api/solicitudes` prefix

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6844cbe109348326987e79a144ca478c