### PR TITLE
Make upload directory configurable

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/service/DocumentoAdjuntoService.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/service/DocumentoAdjuntoService.java
@@ -6,6 +6,7 @@ import cl.duoc.sistema_aduanero.repository.DocumentoAdjuntoRepository;
 import cl.duoc.sistema_aduanero.repository.SolicitudAduanaRepository;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
@@ -20,14 +21,15 @@ public class DocumentoAdjuntoService {
     @Autowired
     private DocumentoAdjuntoRepository documentoAdjuntoRepository;
 
-    private final String BASE_PATH = "C:/Users/ragal/IdeaProjects/sistema_aduanero/uploads";
+    @Value("${app.upload.base-dir}")
+    private String basePath;
 
     public AdjuntoViajeMenores guardarArchivo(SolicitudViajeMenores solicitud, String tipoDocumento, MultipartFile archivo) throws IOException {
         if (archivo == null || archivo.isEmpty()) {
             throw new IllegalArgumentException("El archivo está vacío");
         }
 
-        String carpetaSolicitud = BASE_PATH + "/solicitud_" + solicitud.getId();
+        String carpetaSolicitud = Paths.get(basePath, "solicitud_" + solicitud.getId()).toString();
         File dir = new File(carpetaSolicitud);
         if (!dir.exists()) {
             dir.mkdirs();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,5 +11,7 @@ spring.jpa.show-sql=true
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=20MB
 
-spring.web.resources.static-locations=file:///C:/Users/ragal/IdeaProjects/sistema_aduanero/uploads/
+app.upload.base-dir=${user.home}/uploads
+
+spring.web.resources.static-locations=file:${app.upload.base-dir}/
 spring.mvc.static-path-pattern=/uploads/**


### PR DESCRIPTION
## Summary
- inject `app.upload.base-dir` in `DocumentoAdjuntoService`
- configure `app.upload.base-dir` and use it for static resources

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_6844cbe382288326a38be9b279e3456a