### PR TITLE
Fix onSubscribe invocation in MultipartBodyPublisher

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/javafx/MultipartBodyPublisher.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/javafx/MultipartBodyPublisher.java
@@ -165,7 +165,6 @@ public class MultipartBodyPublisher implements HttpRequest.BodyPublisher {
         BodySubscription(Flow.Subscriber<? super ByteBuffer> subscriber, List<ByteBuffer> bufs) {
             this.subscriber = subscriber;
             this.iterator = bufs.iterator();
-            subscriber.onSubscribe(this);
         }
 
         @Override

--- a/src/test/java/cl/duoc/sistema_aduanero/javafx/MultipartBodyPublisherTest.java
+++ b/src/test/java/cl/duoc/sistema_aduanero/javafx/MultipartBodyPublisherTest.java
@@ -1,0 +1,49 @@
+package cl.duoc.sistema_aduanero.javafx;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MultipartBodyPublisherTest {
+
+    @Test
+    void onSubscribeCalledOnlyOnce() {
+        MultipartBodyPublisher.MultipartBuilder builder = MultipartBodyPublisher.builder();
+        builder.addPart("field", "value");
+        MultipartBodyPublisher publisher = builder.build();
+
+        AtomicInteger count = new AtomicInteger();
+
+        Flow.Subscriber<ByteBuffer> subscriber = new Flow.Subscriber<>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                count.incrementAndGet();
+                // request all items
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer item) {
+                // no-op
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                // no-op
+            }
+
+            @Override
+            public void onComplete() {
+                // no-op
+            }
+        };
+
+        publisher.subscribe(subscriber);
+
+        assertEquals(1, count.get(), "onSubscribe should be called exactly once");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `subscriber.onSubscribe()` is invoked only once
- add unit test validating the single invocation

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844cbe54e208326987f6697201ac7f9