### PR TITLE
Fix obtenerPorId Optional handling

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -58,18 +59,18 @@ public class SolicitudAduanaController {
 
     @GetMapping("/{id}")
     public ResponseEntity<SolicitudViajeMenores> obtenerPorId(@PathVariable Long id) {
-        SolicitudViajeMenores s = service.obtenerPorId(id);
-        if (s == null) return ResponseEntity.notFound().build();
-        return ResponseEntity.ok(s);
+        Optional<SolicitudViajeMenores> s = service.obtenerPorId(id);
+        return s.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @GetMapping("/descargar/{id}")
     public ResponseEntity<InputStreamResource> descargarTodosLosDocumentos(@PathVariable Long id) {
         try {
-            SolicitudViajeMenores solicitud = solicitudService.obtenerPorId(id);
-            if (solicitud == null) {
+            Optional<SolicitudViajeMenores> solicitudOpt = solicitudService.obtenerPorId(id);
+            if (solicitudOpt.isEmpty()) {
                 return ResponseEntity.notFound().build();
             }
+            SolicitudViajeMenores solicitud = solicitudOpt.get();
 
             String nombreZip = "solicitud_" + id + "_documentos.zip";
 

--- a/src/main/java/cl/duoc/sistema_aduanero/service/SolicitudAduanaService.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/service/SolicitudAduanaService.java
@@ -4,6 +4,7 @@ import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
 import cl.duoc.sistema_aduanero.repository.SolicitudAduanaRepository;
 import org.springframework.stereotype.Service;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class SolicitudAduanaService {
@@ -29,9 +30,8 @@ public class SolicitudAduanaService {
         return repository.save(solicitud);
     }
 
-    public SolicitudViajeMenores obtenerPorId(Long id) {
-        return repository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Solicitud no encontrada"));
+    public Optional<SolicitudViajeMenores> obtenerPorId(Long id) {
+        return repository.findById(id);
 
     }
 }


### PR DESCRIPTION
## Summary
- return `Optional<SolicitudViajeMenores>` in `SolicitudAduanaService.obtenerPorId`
- adjust `SolicitudAduanaController` to use `Optional` when fetching a request

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_6844cbe704908326a415a3babb2c1119