### PR TITLE
Add DTO layer and update controller

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -1,5 +1,8 @@
 package cl.duoc.sistema_aduanero.controller;
 
+import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresRequest;
+import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresResponse;
+import cl.duoc.sistema_aduanero.dto.AdjuntoViajeMenoresResponse;
 import cl.duoc.sistema_aduanero.model.AdjuntoViajeMenores;
 import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
 import cl.duoc.sistema_aduanero.service.DocumentoAdjuntoService;
@@ -34,31 +37,37 @@ public class SolicitudAduanaController {
   }
 
   @PostMapping
-  public ResponseEntity<SolicitudViajeMenores>
-  crear(@RequestBody SolicitudViajeMenores solicitud) {
-    return new ResponseEntity<>(solicitudService.crearSolicitud(solicitud),
-                                HttpStatus.CREATED);
+  public ResponseEntity<SolicitudViajeMenoresResponse>
+  crear(@RequestBody SolicitudViajeMenoresRequest solicitud) {
+    SolicitudViajeMenores entidad = solicitud.toEntity();
+    SolicitudViajeMenores guardada = solicitudService.crearSolicitud(entidad);
+    return new ResponseEntity<>(
+        SolicitudViajeMenoresResponse.fromEntity(guardada), HttpStatus.CREATED);
   }
 
   @GetMapping
-  public List<SolicitudViajeMenores> listar() {
-    return solicitudService.obtenerTodas();
+  public List<SolicitudViajeMenoresResponse> listar() {
+    return solicitudService.obtenerTodas().stream()
+        .map(SolicitudViajeMenoresResponse::fromEntity)
+        .toList();
   }
 
   @PutMapping("/{id}/estado")
-  public ResponseEntity<SolicitudViajeMenores>
+  public ResponseEntity<SolicitudViajeMenoresResponse>
   actualizarEstado(@PathVariable Long id, @RequestParam String estado) {
-    return ResponseEntity.ok(solicitudService.actualizarEstado(id, estado));
+    SolicitudViajeMenores act = solicitudService.actualizarEstado(id, estado);
+    return ResponseEntity.ok(SolicitudViajeMenoresResponse.fromEntity(act));
   }
 
   @GetMapping("/{id}")
-  public ResponseEntity<SolicitudViajeMenores>
+  public ResponseEntity<SolicitudViajeMenoresResponse>
   obtenerPorId(@PathVariable Long id) {
 
     Optional<SolicitudViajeMenores> s = solicitudService.obtenerPorId(id);
-    if (s == null)
+    if (s.isEmpty()) {
       return ResponseEntity.notFound().build();
-    return ResponseEntity.ok(s.get());
+    }
+    return ResponseEntity.ok(SolicitudViajeMenoresResponse.fromEntity(s.get()));
   }
 
   @GetMapping("/descargar/{id}")
@@ -126,7 +135,7 @@ public class SolicitudAduanaController {
   }
 
   @PostMapping("/adjuntar")
-  public ResponseEntity<SolicitudViajeMenores>
+  public ResponseEntity<SolicitudViajeMenoresResponse>
   crearConAdjunto(@RequestParam String nombreSolicitante,
                   @RequestParam String tipoDocumento,
                   @RequestParam String numeroDocumento,
@@ -141,7 +150,8 @@ public class SolicitudAduanaController {
 
       adjuntoService.guardarArchivo(guardada, tipoAdjunto, archivo);
 
-      return new ResponseEntity<>(guardada, HttpStatus.CREATED);
+      return new ResponseEntity<>(
+          SolicitudViajeMenoresResponse.fromEntity(guardada), HttpStatus.CREATED);
 
     } catch (IOException e) {
       return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/cl/duoc/sistema_aduanero/dto/AdjuntoViajeMenoresRequest.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/dto/AdjuntoViajeMenoresRequest.java
@@ -1,0 +1,21 @@
+package cl.duoc.sistema_aduanero.dto;
+
+import cl.duoc.sistema_aduanero.model.AdjuntoViajeMenores;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdjuntoViajeMenoresRequest {
+    private String nombreArchivo;
+    private String ruta;
+
+    public AdjuntoViajeMenores toEntity() {
+        AdjuntoViajeMenores adj = new AdjuntoViajeMenores();
+        adj.setNombreArchivo(nombreArchivo);
+        adj.setRuta(ruta);
+        return adj;
+    }
+}

--- a/src/main/java/cl/duoc/sistema_aduanero/dto/AdjuntoViajeMenoresResponse.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/dto/AdjuntoViajeMenoresResponse.java
@@ -1,0 +1,20 @@
+package cl.duoc.sistema_aduanero.dto;
+
+import cl.duoc.sistema_aduanero.model.AdjuntoViajeMenores;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdjuntoViajeMenoresResponse {
+    private Long id;
+    private String nombreArchivo;
+    private String ruta;
+
+    public static AdjuntoViajeMenoresResponse fromEntity(AdjuntoViajeMenores adj) {
+        if (adj == null) return null;
+        return new AdjuntoViajeMenoresResponse(adj.getId(), adj.getNombreArchivo(), adj.getRuta());
+    }
+}

--- a/src/main/java/cl/duoc/sistema_aduanero/dto/SolicitudViajeMenoresRequest.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/dto/SolicitudViajeMenoresRequest.java
@@ -1,0 +1,54 @@
+package cl.duoc.sistema_aduanero.dto;
+
+import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SolicitudViajeMenoresRequest {
+    private String estado;
+    private String tipoSolicitudMenor;
+    private String nombreMenor;
+    private LocalDateTime fechaNacimientoMenor;
+    private String documentoMenor;
+    private String numeroDocumentoMenor;
+    private String nacionalidadMenor;
+    private String nombrePadreMadre;
+    private String relacionMenor;
+    private String documentoPadre;
+    private String numeroDocumentoPadre;
+    private String telefonoPadre;
+    private String emailPadre;
+    private LocalDateTime fechaViaje;
+    private String numeroTransporte;
+    private String paisOrigen;
+    private String paisDestino;
+    private String motivoViaje;
+
+    public SolicitudViajeMenores toEntity() {
+        SolicitudViajeMenores s = new SolicitudViajeMenores();
+        s.setEstado(estado);
+        s.setTipoSolicitudMenor(tipoSolicitudMenor);
+        s.setNombreMenor(nombreMenor);
+        s.setFechaNacimientoMenor(fechaNacimientoMenor);
+        s.setDocumentoMenor(documentoMenor);
+        s.setNumeroDocumentoMenor(numeroDocumentoMenor);
+        s.setNacionalidadMenor(nacionalidadMenor);
+        s.setNombrePadreMadre(nombrePadreMadre);
+        s.setRelacionMenor(relacionMenor);
+        s.setDocumentoPadre(documentoPadre);
+        s.setNumeroDocumentoPadre(numeroDocumentoPadre);
+        s.setTelefonoPadre(telefonoPadre);
+        s.setEmailPadre(emailPadre);
+        s.setFechaViaje(fechaViaje);
+        s.setNumeroTransporte(numeroTransporte);
+        s.setPaisOrigen(paisOrigen);
+        s.setPaisDestino(paisDestino);
+        s.setMotivoViaje(motivoViaje);
+        return s;
+    }
+}

--- a/src/main/java/cl/duoc/sistema_aduanero/dto/SolicitudViajeMenoresResponse.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/dto/SolicitudViajeMenoresResponse.java
@@ -1,0 +1,68 @@
+package cl.duoc.sistema_aduanero.dto;
+
+import cl.duoc.sistema_aduanero.model.AdjuntoViajeMenores;
+import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SolicitudViajeMenoresResponse {
+    private Long id;
+    private String estado;
+    private LocalDateTime fechaCreacion;
+    private String tipoSolicitudMenor;
+    private String nombreMenor;
+    private LocalDateTime fechaNacimientoMenor;
+    private String documentoMenor;
+    private String numeroDocumentoMenor;
+    private String nacionalidadMenor;
+    private String nombrePadreMadre;
+    private String relacionMenor;
+    private String documentoPadre;
+    private String numeroDocumentoPadre;
+    private String telefonoPadre;
+    private String emailPadre;
+    private LocalDateTime fechaViaje;
+    private String numeroTransporte;
+    private String paisOrigen;
+    private String paisDestino;
+    private String motivoViaje;
+    private List<AdjuntoViajeMenoresResponse> documentos;
+
+    public static SolicitudViajeMenoresResponse fromEntity(SolicitudViajeMenores s) {
+        if (s == null) return null;
+        SolicitudViajeMenoresResponse dto = new SolicitudViajeMenoresResponse();
+        dto.setId(s.getId());
+        dto.setEstado(s.getEstado());
+        dto.setFechaCreacion(s.getFechaCreacion());
+        dto.setTipoSolicitudMenor(s.getTipoSolicitudMenor());
+        dto.setNombreMenor(s.getNombreMenor());
+        dto.setFechaNacimientoMenor(s.getFechaNacimientoMenor());
+        dto.setDocumentoMenor(s.getDocumentoMenor());
+        dto.setNumeroDocumentoMenor(s.getNumeroDocumentoMenor());
+        dto.setNacionalidadMenor(s.getNacionalidadMenor());
+        dto.setNombrePadreMadre(s.getNombrePadreMadre());
+        dto.setRelacionMenor(s.getRelacionMenor());
+        dto.setDocumentoPadre(s.getDocumentoPadre());
+        dto.setNumeroDocumentoPadre(s.getNumeroDocumentoPadre());
+        dto.setTelefonoPadre(s.getTelefonoPadre());
+        dto.setEmailPadre(s.getEmailPadre());
+        dto.setFechaViaje(s.getFechaViaje());
+        dto.setNumeroTransporte(s.getNumeroTransporte());
+        dto.setPaisOrigen(s.getPaisOrigen());
+        dto.setPaisDestino(s.getPaisDestino());
+        dto.setMotivoViaje(s.getMotivoViaje());
+        if (s.getDocumentos() != null) {
+            dto.setDocumentos(s.getDocumentos().stream()
+                .map(AdjuntoViajeMenoresResponse::fromEntity)
+                .collect(Collectors.toList()));
+        }
+        return dto;
+    }
+}

--- a/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
+++ b/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresRequest;
 import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
 import cl.duoc.sistema_aduanero.service.DocumentoAdjuntoService;
 import cl.duoc.sistema_aduanero.service.SolicitudAduanaService;
@@ -38,10 +39,12 @@ class SolicitudAduanaControllerTest {
         .when(solicitudService.crearSolicitud(any(SolicitudViajeMenores.class)))
         .thenReturn(solicitud);
 
+    SolicitudViajeMenoresRequest req = new SolicitudViajeMenoresRequest();
+
     mockMvc
         .perform(post("/api/solicitudes")
                      .contentType(MediaType.APPLICATION_JSON)
-                     .content(objectMapper.writeValueAsString(solicitud)))
+                     .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").value(1L));
   }


### PR DESCRIPTION
## Summary
- add request/response DTOs for `SolicitudViajeMenores` and `AdjuntoViajeMenores`
- update `SolicitudAduanaController` to use the DTOs
- adjust controller unit test for the new API

## Testing
- `mvnw test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844d35a19e08326bfc01c49a6e50f24