### PR TITLE
Fix Optional handling in solicitud service

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -55,8 +55,13 @@ public class SolicitudAduanaController {
   @PutMapping("/{id}/estado")
   public ResponseEntity<SolicitudViajeMenoresResponse>
   actualizarEstado(@PathVariable Long id, @RequestParam String estado) {
-    SolicitudViajeMenores act = solicitudService.actualizarEstado(id, estado);
-    return ResponseEntity.ok(SolicitudViajeMenoresResponse.fromEntity(act));
+    Optional<SolicitudViajeMenores> actOpt =
+        solicitudService.actualizarEstado(id, estado);
+    if (actOpt.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+    return ResponseEntity.ok(
+        SolicitudViajeMenoresResponse.fromEntity(actOpt.get()));
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/cl/duoc/sistema_aduanero/service/SolicitudAduanaService.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/service/SolicitudAduanaService.java
@@ -23,11 +23,15 @@ public class SolicitudAduanaService {
     return repository.findAll();
   }
 
-  public SolicitudViajeMenores actualizarEstado(Long id, String nuevoEstado) {
-    SolicitudViajeMenores solicitud = repository.findById(id).orElseThrow(
-        () -> new RuntimeException("Solicitud no encontrada"));
+  public Optional<SolicitudViajeMenores> actualizarEstado(Long id,
+                                                          String nuevoEstado) {
+    Optional<SolicitudViajeMenores> opt = repository.findById(id);
+    if (opt.isEmpty()) {
+      return Optional.empty();
+    }
+    SolicitudViajeMenores solicitud = opt.get();
     solicitud.setEstado(nuevoEstado);
-    return repository.save(solicitud);
+    return Optional.of(repository.save(solicitud));
   }
 
   public Optional<SolicitudViajeMenores> obtenerPorId(Long id) {


### PR DESCRIPTION
## Summary
- update `SolicitudAduanaService.actualizarEstado` to return `Optional`
- handle missing solicitud in controller when updating state

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6844d4ff4e048326992ae44ed5ecfe71