### PR TITLE
Fix AdjuntoViajeMenoresResponse constructor

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/dto/AdjuntoViajeMenoresResponse.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/dto/AdjuntoViajeMenoresResponse.java
@@ -1,18 +1,57 @@
 package cl.duoc.sistema_aduanero.dto;
 
 import cl.duoc.sistema_aduanero.model.AdjuntoViajeMenores;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
+/** DTO para exponer la información de los adjuntos. */
 public class AdjuntoViajeMenoresResponse {
     private Long id;
     private String nombreOriginal;
     private String nombreArchivo;
     private String ruta;
+
+    public AdjuntoViajeMenoresResponse() {}
+
+    public AdjuntoViajeMenoresResponse(Long id,
+                                        String nombreOriginal,
+                                        String nombreArchivo,
+                                        String ruta) {
+        this.id = id;
+        this.nombreOriginal = nombreOriginal;
+        this.nombreArchivo = nombreArchivo;
+        this.ruta = ruta;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombreOriginal() {
+        return nombreOriginal;
+    }
+
+    public void setNombreOriginal(String nombreOriginal) {
+        this.nombreOriginal = nombreOriginal;
+    }
+
+    public String getNombreArchivo() {
+        return nombreArchivo;
+    }
+
+    public void setNombreArchivo(String nombreArchivo) {
+        this.nombreArchivo = nombreArchivo;
+    }
+
+    public String getRuta() {
+        return ruta;
+    }
+
+    public void setRuta(String ruta) {
+        this.ruta = ruta;
+    }
 
     public static AdjuntoViajeMenoresResponse fromEntity(AdjuntoViajeMenores adj) {
         if (adj == null) return null;


### PR DESCRIPTION
## Summary
- remove Lombok dependency from AdjuntoViajeMenoresResponse
- add explicit constructor, getters and setters

## Testing
- `./mvnw -q -e -DskipTests=false test` *(fails: Failed to fetch apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68451ffaba388326a6da9784b6b22560