### PR TITLE
Set default estado to PENDIENTE

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -36,7 +36,11 @@ public class SolicitudAduanaController {
       @ModelAttribute SolicitudViajeMenoresRequest request) {
     try {
       SolicitudViajeMenores solicitud = new SolicitudViajeMenores();
-      solicitud.setEstado(request.getEstado());
+      String estado = request.getEstado();
+      if (estado == null || estado.trim().isEmpty()) {
+        estado = "PENDIENTE";
+      }
+      solicitud.setEstado(estado);
       solicitud.setTipoSolicitudMenor(request.getTipoSolicitudMenor());
       solicitud.setNombreMenor(request.getNombreMenor());
       solicitud.setFechaNacimientoMenor(request.getFechaNacimientoMenor());

--- a/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
+++ b/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
@@ -1,10 +1,12 @@
 package cl.duoc.sistema_aduanero.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import org.mockito.ArgumentCaptor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import cl.duoc.sistema_aduanero.dto.AdjuntoViajeMenoresRequest;
 import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
 import cl.duoc.sistema_aduanero.service.DocumentoAdjuntoService;
 import cl.duoc.sistema_aduanero.service.SolicitudAduanaService;
@@ -51,7 +53,29 @@ class SolicitudAduanaControllerTest {
                      .file(file1)
                      .file(file2)
                      .file(file3)
-                     .param("estado", "NUEVA"))
+        .param("estado", "NUEVA"))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  void crearSinEstadoUsaPendiente() throws Exception {
+    SolicitudViajeMenores solicitud = new SolicitudViajeMenores();
+    solicitud.setId(4L);
+
+    Mockito
+        .when(solicitudService.crearSolicitud(any(SolicitudViajeMenores.class)))
+        .thenReturn(solicitud);
+    Mockito
+        .when(adjuntoService.guardarAdjuntos(any(), any(), any()))
+        .thenReturn(Collections.emptyList());
+
+    mockMvc
+        .perform(multipart("/api/solicitudes"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<SolicitudViajeMenores> captor =
+        ArgumentCaptor.forClass(SolicitudViajeMenores.class);
+    verify(solicitudService).crearSolicitud(captor.capture());
+    assertEquals("PENDIENTE", captor.getValue().getEstado());
   }
 }


### PR DESCRIPTION
## Summary
- default estado to `PENDIENTE` in `SolicitudAduanaController`
- add unit test verifying default value

## Testing
- `mvn test` *(fails: mvn not found)*
- `./mvnw test` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6845344ecae08326adbcbdb8705f3f49