### PR TITLE
Validate Chile for entry/exit

### DIFF
--- a/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -55,8 +55,19 @@ public class SolicitudAduanaController {
       solicitud.setEmailPadre(request.getEmailPadre());
       solicitud.setFechaViaje(request.getFechaViaje());
       solicitud.setNumeroTransporte(request.getNumeroTransporte());
-      solicitud.setPaisOrigen(request.getPaisOrigen());
-      solicitud.setPaisDestino(request.getPaisDestino());
+
+      String tipo = request.getTipoSolicitudMenor();
+      if ("Entrada".equalsIgnoreCase(tipo)) {
+        solicitud.setPaisOrigen(request.getPaisOrigen());
+        solicitud.setPaisDestino("Chile");
+      } else if ("Salida".equalsIgnoreCase(tipo)) {
+        solicitud.setPaisOrigen("Chile");
+        solicitud.setPaisDestino(request.getPaisDestino());
+      } else {
+        solicitud.setPaisOrigen(request.getPaisOrigen());
+        solicitud.setPaisDestino(request.getPaisDestino());
+      }
+
       solicitud.setMotivoViaje(request.getMotivoViaje());
 
       SolicitudViajeMenores creada = solicitudService.crearSolicitud(solicitud);

--- a/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
+++ b/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
@@ -78,4 +78,46 @@ class SolicitudAduanaControllerTest {
     verify(solicitudService).crearSolicitud(captor.capture());
     assertEquals("PENDIENTE", captor.getValue().getEstado());
   }
+
+  @Test
+  void entradaFijaDestinoChile() throws Exception {
+    SolicitudViajeMenores solicitud = new SolicitudViajeMenores();
+    solicitud.setId(5L);
+
+    Mockito
+        .when(solicitudService.crearSolicitud(any(SolicitudViajeMenores.class)))
+        .thenReturn(solicitud);
+
+    mockMvc
+        .perform(multipart("/api/solicitudes")
+                     .param("tipoSolicitudMenor", "Entrada")
+                     .param("paisDestino", "Peru"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<SolicitudViajeMenores> captor =
+        ArgumentCaptor.forClass(SolicitudViajeMenores.class);
+    verify(solicitudService).crearSolicitud(captor.capture());
+    assertEquals("Chile", captor.getValue().getPaisDestino());
+  }
+
+  @Test
+  void salidaFijaOrigenChile() throws Exception {
+    SolicitudViajeMenores solicitud = new SolicitudViajeMenores();
+    solicitud.setId(6L);
+
+    Mockito
+        .when(solicitudService.crearSolicitud(any(SolicitudViajeMenores.class)))
+        .thenReturn(solicitud);
+
+    mockMvc
+        .perform(multipart("/api/solicitudes")
+                     .param("tipoSolicitudMenor", "Salida")
+                     .param("paisOrigen", "Argentina"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<SolicitudViajeMenores> captor =
+        ArgumentCaptor.forClass(SolicitudViajeMenores.class);
+    verify(solicitudService).crearSolicitud(captor.capture());
+    assertEquals("Chile", captor.getValue().getPaisOrigen());
+  }
 }


### PR DESCRIPTION
## Summary
- enforce that travel requests set `paisDestino` to Chile for "Entrada" and `paisOrigen` to Chile for "Salida"
- test controller behaviour for these new validations

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68453a80779c832689c33c0d9447b760